### PR TITLE
GHA: fix condition for npm publish

### DIFF
--- a/.github/workflows/ui-pipeline.yaml
+++ b/.github/workflows/ui-pipeline.yaml
@@ -36,7 +36,7 @@ jobs:
           cd ui && make build
 
       - name: Publish package
-        if: github.event_name == 'create' && startsWith(github.ref, 'refs/tags/v')
+        if: startsWith(github.ref, 'refs/tags/v')
         env:
           GITHUB_TOKEN: ${{ secrets.ROBOT_ROX_GITHUB_TOKEN }}
         run: |


### PR DESCRIPTION
Fixing condition according to https://stackoverflow.com/questions/58475748/github-actions-how-to-check-if-current-push-has-new-tag-is-new-release. 